### PR TITLE
delivers attestation for all releases but nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
     # required to allow gh to work
     - uses: actions/checkout@v4
@@ -127,6 +129,10 @@ jobs:
     - run: |
         ls dist
       shell: bash
+    # forge attestation for release
+    - uses: actions/attest@v2
+      with:
+        subject-path:  dist/*.*
     - name: deploy release
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
See https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds

Add a CD-level attestation that demonstrate the authentication of the release assets. Can be verified at browser level or through gh CLI